### PR TITLE
Fix served model name

### DIFF
--- a/chart/templates/vllm/vllm-runtime.yaml
+++ b/chart/templates/vllm/vllm-runtime.yaml
@@ -13,7 +13,7 @@ spec:
   containers:
     - args:
         - --model=/mnt/models
-        - --served-model-name={{.Name}}
+        - '--served-model-name=microsoft/phi-2'
         - --dtype
         - float16
         - --max-lora-rank


### PR DESCRIPTION
`--served-model-name={{.Name}}` gets interpreted by Helm as `--served-model-name=""` when it is applied to the cluster instead of using the downwards API.

If you want to use the downwards API in Helm you have to escape it like this:

```
- --served-model-name={{ "{{" }} .Name {{ "}}" }} {{/* Escaping brackets for downward API template */}}
```

However, since the model name you are looking for is `microsoft/phi2` you probably just want to hard code the model name in instead of using the downwards API:

```
- --served-model-name=microsoft/phi-2
```

I was getting an empty name for the model from vLLM without this and litellm was throwing 404 errors because it couldn't find the phi-2 model.
